### PR TITLE
Tweak title and Open Graph tags

### DIFF
--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -3,7 +3,7 @@ full_uri  = http://act.perlconference.org/tpc-2018-glasgow/
 languages = en 
 default_language = en
 default_country  = uk
-name_en   = Yet Another Perl Conference :: Europe :: 2018
+name_en   = The Perl Conference in Glasgow :: Europe :: 2018
 timezone  = Europe/London
 
 [registration]

--- a/actdocs/static/index.html
+++ b/actdocs/static/index.html
@@ -1,4 +1,4 @@
-[% WRAPPER ui title = global.conference.name %]
+[% WRAPPER ui %]
 
 <div class="row toprow">   
   <div class="col">

--- a/actdocs/static/workshops.html
+++ b/actdocs/static/workshops.html
@@ -1,4 +1,4 @@
-[% WRAPPER ui title = 'Workshops - ' _ global.conference.name %]
+[% WRAPPER ui title = 'Workshops' %]
 
 <div class="row toprow">
   <div class="col">

--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -2,8 +2,7 @@
 <html>
 
 <head>
-<!-- [% global.request.r.uri %] -->
-<!-- [% global.request.base_url %] -->
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- Document Metadata -->
 <meta http-equiv="Content-Language" content="[% global.request.language %]" />
@@ -11,7 +10,7 @@
 <meta name="twitter:image" content="[% global.config.general_full_uri %]css/logos/lrg-conf-logo.png"/>
 <meta property="og:title" content="[% IF title; title; %] :: [% END %][% global.conference.name %]" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="[% global.config.general_full_uri %]" />
+<meta property="og:url" content="[% global.request.base_url %][% global.request.r.uri %] " />
 <meta property="og:description" content="#TPCiG is the European Perl Conference for 2018: bit.ly/TPCiG" />
 <meta property="og:image" content="[% global.config.general_full_uri %]css/logos/lrg-conf-logo.png" />
 <!-- OpenId -->

--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -3,7 +3,7 @@
 
 <head>
 <!-- [% global.request.r.uri %] -->
-<!-- [% global.request.r.base_url %] -->
+<!-- [% global.request.base_url %] -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- Document Metadata -->
 <meta http-equiv="Content-Language" content="[% global.request.language %]" />
@@ -21,7 +21,7 @@
 <!-- Atom news feed -->
 <link rel="alternate" type="application/atom+xml" title="[% global.conference.name %]"
       href="[% global.request.base_url %][% make_uri_info( 'atom', global.request.language ) %].xml" />
-[%- IF title -%]<title>[% title  %]</title>[%- END -%]
+<title>[% IF title; title %] :: [% END %][% global.conference.name %]</title>
 
 <!-- CSS Stylesheets -->
 <link rel="stylesheet" type="text/css" href="[% make_uri_info('lib/bootstrap/css/bootstrap.min.css') %]" />

--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -2,16 +2,18 @@
 <html>
 
 <head>
+<!-- [% global.request.r.uri %] -->
+<!-- [% global.request.r.base_url %] -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- Document Metadata -->
 <meta http-equiv="Content-Language" content="[% global.request.language %]" />
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:image" content="http://act.perlconference.org/tpc-2018-glasgow/css/logos/lrg-conf-logo.png"/>
-<meta property="og:title" content="[% IF title; title; ELSE %]The Perl Conference - Glasgow 2018[% END %]" />
+<meta name="twitter:image" content="[% global.config.general_full_uri %]css/logos/lrg-conf-logo.png"/>
+<meta property="og:title" content="[% IF title; title; %] :: [% END %][% global.conference.name %]" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://act.perlconference.org/tpc-2018-glasgow/" />
+<meta property="og:url" content="[% global.config.general_full_uri %]" />
 <meta property="og:description" content="#TPCiG is the European Perl Conference for 2018: bit.ly/TPCiG" />
-<meta property="og:image" content="http://act.perlconference.org/tpc-2018-glasgow/css/logos/lrg-conf-logo.png" />
+<meta property="og:image" content="[% global.config.general_full_uri %]css/logos/lrg-conf-logo.png" />
 <!-- OpenId -->
 [% IF openid %]
 <link rel="openid.server" href="[% global.request.base_url %][% make_uri('openid') %]" />


### PR DESCRIPTION
Three main changes here:

* Change the conference name to be "The Perl Conference" rather than "YAPC"
* Include the conference name in the title of every page
* Fix the content of the ""og:url" tag on every page

(@andrewsolomon - turns out I have write access to master, so I didn't need to do pull requests at all.)