### PR TITLE
Information about the venue and attending are on top. 

### DIFF
--- a/actdocs/static/index.html
+++ b/actdocs/static/index.html
@@ -14,26 +14,64 @@
 <div class="row middlerow">
     <div class="col">
       <h3 class="generations">
-        Welcome to Glasgow
-      </h3>
-      <h4>
-        The Studio, 13th-17th August 2018
-      </h4>
-      <h4>Deadline for talk proposals: Saturday, 30th June</h4>
-      <p>
-        Perl has been in the public domain for thirty years and 2018 is the thirty-first year, this marks a second generation. So what do we want to show from the first generation and first thirty years? What do the next thirty years of Perl look like? We invite you to think on this as you submit your talks but do not feel constrained by the theme.
-      </p>
-      <p>
-        The Perl Conference is an open and welcoming community event and as such we welcome submission on any subject. Do not feel imprisoned by a particular language. We welcome talks on other languages and technical matters relating to programming and software development, we also welcome community and infrastructure talks.
-      </p>
-      <h3 class="generations">
-        About The Perl Conference
+        About The Perl Conference 
       </h3>
       <p>
         The Perl Conference - which in the Perl community is usually referred to as Yet Another Perl Conference Europe (YAPC::EU) - is the annual meeting of Perl Mongers, developers, administrators, technical managers and interested parties in Europe. In 2018 the European Perl Conference will be held at The Studio in Glasgow between 13th-17th August.
       </p>
       <p>
         YAPC started off as a series of grassroots user meetings, with discussions among Perl Mongers, and has grown from there. The very first OSCON grew out of the original Perl Conference. The focus is on enjoying the ideas of others, discovering new concepts, and feeling the enthusiasm of fellow programmers. Although our conference is devoted primarily to the Perl 5 and Perl 6 programming languages we appreciate and value discussions and submissions from other languages and technical disciplines.
+      </p>
+      <h4> 
+        Perl Generations
+      </h4>
+      <h4>Deadline for talk proposals: Saturday, 30th June</h4>
+      <p>
+        The theme of this year comes from Perl having been in the public domain for thirty years and 2018 is the thirty-first year, marking a second generation . So what do we want to show from the first generation and first thirty years? What do the next thirty years of Perl look like? We invite you to think on this as you submit your talks but do not feel constrained by the theme.
+      </p>
+      <p>
+        The Perl Conference is an open and welcoming community event and as such we welcome submission on any subject. Do not feel imprisoned by a particular language. We welcome talks on other languages and technical matters relating to programming and software development, we also welcome community and infrastructure talks.
+      </p>
+      <p>
+        The call for workshops has closed and we have secured our speakers and events. The call for talks (short, long and lightning) is still open until 30th June so go and submit a talk proposal now. The organisers have been accepting talks throughout the year and will continue to do so.
+      </p>
+      <p> To submit your talk you can do it <a href="http://act.perlconference.org/tpc-2018-glasgow/newtalk"> here </a>
+      <h4> 
+        Planning your attendance
+      </h4>
+        <p>
+         The conference will be held over five days between 13-17th August 2018 at <a href="http://studiovenues.co.uk/venues/glasgow/">The Studio</a> located at 67 Hope Street, Glasgow, G2 6AE, in the centre of Glasgow. The first two days will be taken up with workshops and training (detailed below) and then 3 days of the main conference.
+        </p>
+        <p>
+        The Perl Conference is a volunteer run event which means we rely on you to help boost the collective experience. Please make sure to add details to the <a href="http://act.perlconference.org/tpc-2018-glasgow/wiki">wiki</a> of when you are arriving and departing and staying (though only if you wish to and you can alter and remove this data at any time)
+        </p>
+        <p>
+         If you want to help out at this year’s event then please don’t hesitate to contact Mark or Rick as soon as possible (we are always looking for help). We would particularly love people who have some spare time to help us with promoting the event (including social media management and outreach) and in organising talks and proposals and liaising with speakers.
+        </p>
+        <p>
+            The <a href="http://act.perlconference.org/tpc-2018-glasgow/wiki">wiki</a> also contains details of BoF sessions and some of the talks alongside a growing collection of helpful advice of:
+        </p>
+        <p>
+        <ul>
+            <li>
+                <a href="https://www.visitscotland.com/destinations-maps/glasgow/accommodation/">
+                    places to stay
+                </a>
+            </li>
+            <li>
+                <a href="https://peoplemakeglasgow.com/visiting/getting-around%20-%20https://www.scotrail.co.uk/plan-your-journey/timetables-and-routes">
+                    travel
+                </a>
+            </li>
+            <li>
+                <a href="http://act.perlconference.org/tpc-2018-glasgow/wiki?node=BeATourist">
+                    tourism
+                </a>
+            </li>
+        </ul>
+      </p>
+      <p>
+       Please note that there is a major sporting event the week before the conference and an International Band Festival following so hotels in the centre of Glasgow are starting to fill up. However there are a large number of surrounding regions that are all within a short rail or bus journey. Glasgow has an extensive public transport system so check out the timetables and routes. If you are a keen camper the beautiful shores of Loch Lomond at 30 minutes away by car or 45 minutes by train and metro.
       </p>
       <p>
         Watch this space for updates, or check the <a href="[% global.request.base_url %][% make_uri_info( 'atom', global.request.language ) %].xml">feed</a>.


### PR DESCRIPTION
This commit makes the information about the venue, submiting talks
and the about the conference more visible.

To this commit make sense someone need to remove the About post
from the blog, since it has repeated information

Move the about with the information of the venue to the top.
After information about the theme and about the talks,
including the warning about the date and the link to submit it
Add a Planning your attendance header where the attendance
information are.

Remove most of repeated glasgow and perl and about words
as this hurt google indexes